### PR TITLE
fix the empty `--store` flag for aws tpcc test

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -104,7 +104,11 @@ function start_cockroach() {
    stores="$stores --store $s/cockroach"
   done
 
-	roachprod start "$CLUSTER":1-$((NODES-1)) --args="$stores --cache=0.25 --max-sql-memory=0.4" 
+  if [[ -z $stores ]]; then
+    stores="--store=/mnt/data1/cockroach"
+  fi
+
+  roachprod start "$CLUSTER":1-$((NODES-1)) --args="$stores --cache=0.25 --max-sql-memory=0.4" 
 }
 
 # Execute setup.sh script on the cluster to configure it


### PR DESCRIPTION
Per @miretskiy's suggestion, since we’re not going to
benchmark local disks for 2022 report, we just store data
under `/mnt/data1/cockroach`.