### PR TITLE
Fix nits in generate.go

### DIFF
--- a/cloudDetails/azure.json
+++ b/cloudDetails/azure.json
@@ -28,7 +28,7 @@
         }
       },
       "Standard_E32as_v4": null,
-      "Standard_E8as_v5": {
+      "Standard_E32as_v5": {
         "roachprodArgs": {
           "azure-locations": "eastus",
           "west-azure-locations": "westus2",

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -46,9 +46,11 @@ func init() {
 
 	generateCmd.Flags().StringVarP(&scriptsDir, "scripts-dir", "",
 		"./scripts", "directory containing scripts uploaded to cloud VMs that execute benchmarks.")
-	// We need to define a longer life-time as we introduced vcpu8 machine
-	// types, which start with a low tpcc store number, and take longer to
-	// complete a run.
+	// We need to define a longer life-time as in general a tpcc run takes 2-3
+	// hours to finish, and occasionally we hit issue(s) which require a re-run
+	// of tpcc, overall more than 4 hours is needed to run a whole test suite,
+	// managing multiple parallel run across a batch of tests also takes longer
+	// to finish a whole batch.
 	generateCmd.Flags().StringVarP(&lifetime, "lifetime", "l",
 		"6h", "cluster lifetime")
 	generateCmd.Flags().StringVar(&usage, "usage", "cloud-report-2022", "the usage label for roachprod create. Default: cloud-report-2022")
@@ -107,6 +109,8 @@ function create_west_cluster() {
 function upload_scripts() {
   roachprod run "$1" rm  -- -rf ./scripts
   roachprod put "$1" {{.ScriptsDir}} scripts
+  echo "{{.MachineType}}" > "machinetype.txt"
+  roachprod put "$1" "machinetype.txt" "machinetype.txt"
   roachprod run "$1" chmod -- -R +x ./scripts
 }
 

--- a/scripts/gen/tpcc.sh
+++ b/scripts/gen/tpcc.sh
@@ -79,12 +79,14 @@ cd "$HOME"
 # These current set of limits are carefully tuned and pretty accurately reflect the
 # limits of the machine types. You have to do the same tuning for new machine types
 # until this bug is resolved with desired behavior.
-vcpu=`grep -Pc '^processor\t' /proc/cpuinfo`
-machinetype=`cat machinetype.txt`
+vcpu=$(grep -Pc '^processor\t' /proc/cpuinfo)
+machinetype=$(cat machinetype.txt)
 if [ $vcpu -gt 16 ]
 then
   f_active=2750
   f_inc=250
+  # Reg expression "r5.\.8xlarge" is for current r5 vcpu32 machine family
+  # including r5a.8xlarge, r5b.8xlarge and r5n.8xlarge.
   if [[ $machinetype =~ r5.\.8xlarge || $machinetype =~ m5a\.8xlarge ]];
   then
     echo "Decreasing upper limit because of machine type $machinetype."
@@ -122,6 +124,8 @@ then
   echo "done importing"
 fi
 
+# if f_inc is not specified, then we set it equal to f_warehouses, this means
+# we just need to run one iteration.
 if [[ $f_inc == 0 ]];
 then
   f_inc=$f_warehouses


### PR DESCRIPTION
Added export of machine type to machinetype.txt and one type in azure.json, which was lost due to a merge issue. Added a few comments to make change clear.

Release note: none