### PR TITLE
add min-cpu-platform, and shrink pd size for gce machines 

### DIFF
--- a/cloudDetails/gce.json
+++ b/cloudDetails/gce.json
@@ -3,38 +3,47 @@
         "group": "pd-ssd",
         "cloud": "gce",
         "machineTypes": {
-            "n2-standard-8": null,
+            "n2-standard-8": {
+                "roachprodArgs": {
+                    "gce-pd-volume-size": "1000"
+                }
+            },
             "n2-standard-32": null,
             "n2d-standard-8":  {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-pd-volume-size": "1000",
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
             "n2d-standard-32":  {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
 
-            "n2-highcpu-8": null,
+            "n2-highcpu-8": {
+                "roachprodArgs": {
+                    "gce-pd-volume-size": "1000"
+                }
+            },
             "n2-highcpu-32": null,
 
             "n2d-highcpu-8":  {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-pd-volume-size": "1000",
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
             "n2d-highcpu-32":  {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
 
             "c2-standard-8": {
+                "roachprodArgs": {
+                    "gce-pd-volume-size": "1000"
+                },
                 "benchArgs": {
                     "tpcc": "-A 1000 -W 1200 -I 100 -d 10m"
                 }
@@ -47,42 +56,29 @@
 
             "n2-highmem-8": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-pd-volume-size": "1000"
                 }
             },
-            "n2-highmem-32": {
-                "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
-                }
-            },
+            "n2-highmem-32": null,
 
             "n2d-highmem-8": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-pd-volume-size": "1000",
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
             "n2d-highmem-32": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
 
             "n2-custom-8-32768": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-pd-volume-size": "1000"
                 }
             },
-            "n2-custom-32-131072": {
-                "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
-                }
-            }
+            "n2-custom-32-131072": null
         },
         "roachprodArgs": {
             "local-ssd": "false",
@@ -91,45 +87,52 @@
             "gce-zones": "us-east4-c",
             "west-gce-zones": "us-west1-a",
             "gce-pd-volume-type": "pd-ssd",
-            "gce-pd-volume-size": "2500"
+            "gce-pd-volume-size": "2500",
+            "gce-min-cpu-platform": "Intel Cascade Lake"
         }
     },
     {
         "group": "pd-extreme",
         "cloud": "gce",
         "machineTypes": {
-            "n2-standard-8": null,
+            "n2-standard-8": {
+                "roachprodArgs": {
+                    "gce-pd-volume-size": "1000"
+                }
+            },
             "n2-standard-32": null,
-            "n2d-standard-8":  {
+            "n2d-standard-8": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-pd-volume-size": "1000",
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
-            "n2d-standard-32":  {
+            "n2d-standard-32": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
-
-            "n2-highcpu-8": null,
+            "n2-highcpu-8": {
+                "roachprodArgs": {
+                    "gce-pd-volume-size": "1000"
+                }
+            },
             "n2-highcpu-32": null,
-
-            "n2d-highcpu-8":  {
+            "n2d-highcpu-8": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-pd-volume-size": "1000",
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
-            "n2d-highcpu-32":  {
+            "n2d-highcpu-32": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
-
             "c2-standard-8": {
+                "roachprodArgs": {
+                    "gce-pd-volume-size": "1000"
+                },
                 "benchArgs": {
                     "tpcc": "-A 1000 -W 1200 -I 100 -d 10m"
                 }
@@ -139,45 +142,29 @@
                     "tpcc": "-A 1000 -W 1200 -I 100 -d 10m"
                 }
             },
-
             "n2-highmem-8": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-pd-volume-size": "1000"
                 }
             },
-            "n2-highmem-32": {
-                "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
-                }
-            },
-
+            "n2-highmem-32": null,
             "n2d-highmem-8": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-pd-volume-size": "1000",
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
             "n2d-highmem-32": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-min-cpu-platform": "AMD Milan"
                 }
             },
-
             "n2-custom-8-32768": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
+                    "gce-pd-volume-size": "1000"
                 }
             },
-            "n2-custom-32-131072": {
-                "roachprodArgs": {
-                    "gce-zones": "us-east1-c",
-                    "west-gce-zones": "us-west1-a"
-                }
-            }
+            "n2-custom-32-131072": null
         },
         "roachprodArgs": {
             "local-ssd": "false",
@@ -186,7 +173,8 @@
             "gce-zones": "us-east4-c",
             "west-gce-zones": "us-west1-a",
             "gce-pd-volume-type": "pd-extreme",
-            "gce-pd-volume-size": "2500"
+            "gce-pd-volume-size": "2500",
+            "gce-min-cpu-platform": "Intel Cascade Lake"
         }
     }
 ]


### PR DESCRIPTION
To see the before/after of adding `--gcp-min-cpu-platform` argument: [here](https://drive.google.com/drive/folders/1B6aIvaGMAcXTBuzqlJPEIM_X9M53Kjh9?usp=sharing) (pls look at each machine's `logs` dir)