### PR TITLE
extend -c (cockroach_binary) CLI option to support staging release version

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -124,7 +124,7 @@ function load_cockroach() {
     roachprod stage "$1" cockroach
   elif [[ $cockroach_binary =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "INFO: staging release version $cockroach_binary of cockroach binary"
-    roachprod stage "$1" cockroach release "$cockroach_binary"
+    roachprod stage "$1" release "$cockroach_binary"
   else
     echo "WARN: staging unknown version of cockroach binary from local path: $cockroach_binary"
     roachprod put "$1" "$cockroach_binary" "cockroach"

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -119,8 +119,14 @@ function load_cockroach() {
   roachprod run "$1" "rm -f ./cockroach"
   if [ -z "$cockroach_binary" ]
   then
+    cockroach_version=$(curl -s -i https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.LATEST |grep location|awk -F"/" '{print $NF}')
+    echo "WARN: staging latest cockroach binary from master: $cockroach_version"
     roachprod stage "$1" cockroach
+  elif [[ $cockroach_binary =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "INFO: staging release version $cockroach_binary of cockroach binary"
+    roachprod stage "$1" cockroach release "$cockroach_binary"
   else
+    echo "WARN: staging unknown version of cockroach binary from local path: $cockroach_binary"
     roachprod put "$1" "$cockroach_binary" "cockroach"
   fi
 }
@@ -332,7 +338,7 @@ Usage: $0 [-b <bootstrap>]... [-w <workload>]... [-d] [-c cockroach_binary]
        -w cr_net : Benchmark Cross-region Net
        -w tpcc: Benchmark TPCC
        -w all : All of the above
-   -c: Override cockroach binary to use.
+   -c: Override cockroach binary to stage (local path to binary or release version)
    -r: Do not start benchmarks specified by -w.  Instead, resume waiting for their completion.
    -I: additional IO benchmark arguments
    -N: additional network benchmark arguments

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,7 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/scripts/gen/tpcc.sh
+++ b/scripts/gen/tpcc.sh
@@ -7,7 +7,7 @@ f_wait=''
 f_active=800
 f_warehouses=1200
 f_skip_load=''
-f_duration="30m"
+f_duration="5m"
 f_inc=200
 
 function usage() {
@@ -83,8 +83,8 @@ vcpu=$(grep -Pc '^processor\t' /proc/cpuinfo)
 machinetype=$(cat machinetype.txt)
 if [ $vcpu -gt 16 ]
 then
-  f_active=2750
-  f_inc=250
+  f_active=3547
+  f_inc=1
   # Reg expression "r5.\.8xlarge" is for current r5 vcpu32 machine family
   # including r5a.8xlarge, r5b.8xlarge and r5n.8xlarge.
   if [[ $machinetype =~ r5.\.8xlarge || $machinetype =~ m5a\.8xlarge ]];
@@ -92,7 +92,7 @@ then
     echo "Decreasing upper limit because of machine type $machinetype."
     f_warehouses=3250
   else
-    f_warehouses=3500
+    f_warehouses=3560
   fi
 elif [ $vcpu -eq 16 ]
 then
@@ -131,6 +131,8 @@ then
   f_inc=$f_warehouses
 fi
 
+echo "Iterating from $f_active until $f_warehouses"
+
 for active in `seq $f_active $f_inc $f_warehouses`
 do
   echo "Running TPCC: $active"
@@ -141,7 +143,7 @@ do
     --ramp=1m --duration="$f_duration" \
     "${pgurls[@]}" > "$report"
 
-    if [[ $(tail -1 "$report" | awk '{if($3 > 85 && $7 < 10000){print "pass"}}') != "pass" ]];
+    if [[ $(tail -1 "$report" | awk '{if(int($3) > 25){print "pass"}}') != "pass" ]];
     then
       break
     fi


### PR DESCRIPTION
There are now three ways to stage cockroach binary,

* `-c ""` yields,
> WARN: staging latest cockroach binary from master: cockroach.linux-gnu-amd64.a6a05fd99a5595f4cbcaa4b9ed525411c8fb68c5

* `-c "/tmp/cockroach"` yields,
> WARN: staging unknown version of cockroach binary from local path: /tmp/cockroach

* `-c "v21.2.3"` yields,
> INFO: staging release version v21.2.3 of cockroach binary