### PR TITLE
remove D*s_v5 and E*s_v5 from ultra disk type

### DIFF
--- a/cloudDetails/azure.json
+++ b/cloudDetails/azure.json
@@ -176,22 +176,7 @@
           "azure-volume-size": "1000"
         }
       },
-      "Standard_E8s_v5":  {
-        "roachprodArgs": {
-          "azure-volume-size": "1000",
-          "azure-locations": "eastus",
-          "west-azure-locations": "westus2",
-          "azure-availability-zone": "1"
-        }
-      },
       "Standard_E32s_v4": null,
-      "Standard_E32s_v5": {
-        "roachprodArgs": {
-          "azure-locations": "eastus",
-          "west-azure-locations": "westus2",
-          "azure-availability-zone": "1"
-        }
-      },
       "Standard_F8s_v2": {
         "roachprodArgs": {
           "azure-volume-size": "1000"
@@ -203,13 +188,7 @@
           "azure-volume-size": "1000"
         }
       },
-      "Standard_D32s_v4": null,
-      "Standard_D8s_v5": {
-        "roachprodArgs": {
-          "azure-volume-size": "1000"
-        }
-      },
-      "Standard_D32s_v5": null
+      "Standard_D32s_v4": null
     },
     "roachprodArgs": {
       "local-ssd": "false",


### PR DESCRIPTION
Per \[[1]\] and  \[[2]\] (search in page "Not every VM size is available in every supported region"), azure's ultra disk doesn't support D*s\_v5 and E*s\_v5.

Resolves https://github.com/cockroachlabs/cloud-report/issues/95

[1]:https://cockroachlabs.slack.com/archives/CJ0H8Q97C/p1641588661056200?thread_ts=1641577797.051200&cid=CJ0H8Q97C
[2]:https://docs.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd?tabs=azure-portal